### PR TITLE
fix: Complete implementation — fix bugs, add missing providers, real async

### DIFF
--- a/src/Config/CheckerConfig.php
+++ b/src/Config/CheckerConfig.php
@@ -4,39 +4,22 @@ declare(strict_types=1);
 
 namespace Qdenka\UltimateLinkChecker\Config;
 
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Psr\SimpleCache\CacheInterface;
-use Qdenka\UltimateLinkChecker\Cache\NullCacheAdapter;
 
 final class CheckerConfig
 {
-    /**
-     * @var CacheInterface|NullCacheAdapter|null
-     */
-    private CacheInterface|NullCacheAdapter|null $cacheAdapter = null;
-    /**
-     * @var int
-     */
+    private ?CacheInterface $cacheAdapter = null;
     private int $cacheTtl = 3600;
-    /**
-     * @var bool
-     */
     private bool $cacheEnabled = false;
-    /**
-     * @var float
-     */
     private float $timeout = 5.0;
-    /**
-     * @var int
-     */
     private int $retries = 1;
-    /**
-     * @var bool
-     */
-    private bool $logEnabled = false;
+    private LoggerInterface $logger;
 
     public function __construct()
     {
-        $this->cacheAdapter = new NullCacheAdapter();
+        $this->logger = new NullLogger();
     }
 
     /**
@@ -136,21 +119,21 @@ final class CheckerConfig
     }
 
     /**
-     * @param bool $enabled
+     * @param LoggerInterface $logger
      * @return $this
      */
-    public function enableLog(bool $enabled = true): self
+    public function setLogger(LoggerInterface $logger): self
     {
-        $this->logEnabled = $enabled;
+        $this->logger = $logger;
 
         return $this;
     }
 
     /**
-     * @return bool
+     * @return LoggerInterface
      */
-    public function isLogEnabled(): bool
+    public function getLogger(): LoggerInterface
     {
-        return $this->logEnabled;
+        return $this->logger;
     }
 }

--- a/src/Contract/AbstractProvider.php
+++ b/src/Contract/AbstractProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Qdenka\UltimateLinkChecker\Contract;
 
-use JetBrains\PhpStorm\Pure;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
@@ -16,7 +15,9 @@ abstract class AbstractProvider implements ProviderInterface
         protected readonly string $apiKey,
         protected readonly ?ClientInterface $httpClient = null,
         protected readonly ?RequestFactoryInterface $requestFactory = null,
-        protected readonly ?StreamFactoryInterface $streamFactory = null
+        protected readonly ?StreamFactoryInterface $streamFactory = null,
+        protected readonly float $timeout = 5.0,
+        protected readonly int $retries = 1
     ) {
     }
 
@@ -52,8 +53,33 @@ abstract class AbstractProvider implements ProviderInterface
      * @param string $url
      * @return CheckResult
      */
-    #[Pure] protected function createResult(string $url): CheckResult
+    protected function createResult(string $url): CheckResult
     {
         return new CheckResult($url);
+    }
+
+    /**
+     * Execute an HTTP request with retry logic.
+     *
+     * @param callable $requestCallable A callable that performs the HTTP request and returns a result.
+     * @return mixed The result of the callable.
+     * @throws \Throwable Re-throws the last exception if all retries fail.
+     */
+    protected function executeWithRetry(callable $requestCallable): mixed
+    {
+        $lastException = null;
+
+        for ($attempt = 0; $attempt <= $this->retries; $attempt++) {
+            try {
+                return $requestCallable();
+            } catch (\Throwable $e) {
+                $lastException = $e;
+                if ($attempt < $this->retries) {
+                    usleep(100_000 * ($attempt + 1)); // Incremental backoff
+                }
+            }
+        }
+
+        throw $lastException;
     }
 }

--- a/src/Factory/ProviderFactory.php
+++ b/src/Factory/ProviderFactory.php
@@ -6,8 +6,11 @@ namespace Qdenka\UltimateLinkChecker\Factory;
 
 use Qdenka\UltimateLinkChecker\Contract\ProviderInterface;
 use Qdenka\UltimateLinkChecker\Exception\InvalidArgumentException;
+use Qdenka\UltimateLinkChecker\Provider\CiscoTalosProvider;
+use Qdenka\UltimateLinkChecker\Provider\FacebookProvider;
 use Qdenka\UltimateLinkChecker\Provider\GoogleSafeBrowsingProvider;
 use Qdenka\UltimateLinkChecker\Provider\IPQualityScoreProvider;
+use Qdenka\UltimateLinkChecker\Provider\OPSWATProvider;
 use Qdenka\UltimateLinkChecker\Provider\PhishTankProvider;
 use Qdenka\UltimateLinkChecker\Provider\VirusTotalProvider;
 use Qdenka\UltimateLinkChecker\Provider\YandexSafeBrowsingProvider;
@@ -17,17 +20,26 @@ final class ProviderFactory
     /**
      * @param string $name
      * @param string $apiKey
+     * @param float $timeout
+     * @param int $retries
      * @return ProviderInterface
      * @throws InvalidArgumentException
      */
-    public static function createProvider(string $name, string $apiKey): ProviderInterface
-    {
+    public static function createProvider(
+        string $name,
+        string $apiKey,
+        float $timeout = 5.0,
+        int $retries = 1
+    ): ProviderInterface {
         return match ($name) {
-            'google_safebrowsing' => new GoogleSafeBrowsingProvider($apiKey),
-            'yandex_safebrowsing' => new YandexSafeBrowsingProvider($apiKey),
-            'virustotal' => new VirusTotalProvider($apiKey),
-            'phishtank' => new PhishTankProvider($apiKey),
-            'ipqualityscore' => new IPQualityScoreProvider($apiKey),
+            'google_safebrowsing' => new GoogleSafeBrowsingProvider($apiKey, timeout: $timeout, retries: $retries),
+            'yandex_safebrowsing' => new YandexSafeBrowsingProvider($apiKey, timeout: $timeout, retries: $retries),
+            'virustotal' => new VirusTotalProvider($apiKey, timeout: $timeout, retries: $retries),
+            'phishtank' => new PhishTankProvider($apiKey, timeout: $timeout, retries: $retries),
+            'ipqualityscore' => new IPQualityScoreProvider($apiKey, timeout: $timeout, retries: $retries),
+            'facebook' => new FacebookProvider($apiKey, timeout: $timeout, retries: $retries),
+            'opswat' => new OPSWATProvider($apiKey, timeout: $timeout, retries: $retries),
+            'cisco_talos' => new CiscoTalosProvider($apiKey, timeout: $timeout, retries: $retries),
             default => throw new InvalidArgumentException(sprintf('Unknown provider "%s"', $name)),
         };
     }
@@ -45,6 +57,9 @@ final class ProviderFactory
             'virustotal',
             'phishtank',
             'ipqualityscore',
+            'facebook',
+            'opswat',
+            'cisco_talos',
         ];
     }
 }

--- a/src/Provider/CiscoTalosProvider.php
+++ b/src/Provider/CiscoTalosProvider.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qdenka\UltimateLinkChecker\Provider;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Psr7\HttpFactory;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Qdenka\UltimateLinkChecker\Contract\AbstractProvider;
+use Qdenka\UltimateLinkChecker\Exception\ProviderException;
+use Qdenka\UltimateLinkChecker\Result\CheckResult;
+use Qdenka\UltimateLinkChecker\Result\Threat;
+
+/**
+ * Cisco Talos Intelligence provider.
+ *
+ * Uses the Cisco Talos reputation lookup API to check URL/domain reputation.
+ * Requires a valid Cisco Talos API key.
+ */
+final class CiscoTalosProvider extends AbstractProvider
+{
+    private const API_URL = 'https://talosintelligence.com/api/v2/url/reputation';
+
+    public function __construct(
+        string $apiKey,
+        ?ClientInterface $httpClient = null,
+        ?RequestFactoryInterface $requestFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
+        float $timeout = 5.0,
+        int $retries = 1
+    ) {
+        parent::__construct(
+            $apiKey,
+            $httpClient ?? new Client(['timeout' => $timeout]),
+            $requestFactory ?? new HttpFactory(),
+            $streamFactory ?? new HttpFactory(),
+            $timeout,
+            $retries
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'cisco_talos';
+    }
+
+    /**
+     * @param string $url
+     * @return CheckResult
+     * @throws ProviderException
+     */
+    public function check(string $url): CheckResult
+    {
+        $normalizedUrl = $this->normalizeUrl($url);
+        $result = $this->createResult($normalizedUrl);
+
+        try {
+            return $this->executeWithRetry(function () use ($normalizedUrl, $result): CheckResult {
+                $domain = $this->extractDomain($normalizedUrl);
+
+                $payload = json_encode(['url' => $domain], JSON_THROW_ON_ERROR);
+
+                $request = $this->requestFactory->createRequest('POST', self::API_URL)
+                    ->withHeader('Content-Type', 'application/json')
+                    ->withHeader('Authorization', 'Bearer ' . $this->apiKey);
+
+                $request = $request->withBody(
+                    $this->streamFactory->createStream($payload)
+                );
+
+                $response = $this->httpClient->sendRequest($request);
+                $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+                $this->processResults($data, $normalizedUrl, $result);
+
+                return $result;
+            });
+        } catch (GuzzleException $e) {
+            throw new ProviderException(
+                sprintf('Error checking URL with Cisco Talos: %s', $e->getMessage()),
+                $e->getCode(),
+                $e
+            );
+        }
+    }
+
+    /**
+     * Process Cisco Talos API results and add threats if found.
+     *
+     * @param array<string, mixed> $data
+     * @param string $url
+     * @param CheckResult $result
+     */
+    private function processResults(array $data, string $url, CheckResult $result): void
+    {
+        $reputation = $data['reputation'] ?? null;
+        $categories = $data['categories'] ?? [];
+
+        // Cisco Talos reputation: "poor" or "very_poor" means dangerous
+        $dangerousReputations = ['poor', 'very_poor', 'untrusted'];
+        $dangerousCategories = [
+            'malware', 'phishing', 'spam', 'botnets',
+            'exploit_kit', 'ransomware', 'cryptomining'
+        ];
+
+        $isDangerous = in_array(strtolower((string) $reputation), $dangerousReputations, true);
+
+        $matchedCategories = [];
+        foreach ($categories as $category) {
+            $categoryName = strtolower(is_array($category) ? ($category['name'] ?? '') : (string) $category);
+            if (in_array($categoryName, $dangerousCategories, true)) {
+                $matchedCategories[] = $categoryName;
+                $isDangerous = true;
+            }
+        }
+
+        if ($isDangerous) {
+            $threatType = $this->determineThreatType($matchedCategories, (string) $reputation);
+
+            $threat = new Threat(
+                type: $threatType,
+                platform: 'ANY_PLATFORM',
+                description: sprintf(
+                    'Cisco Talos rates this URL with reputation "%s"%s',
+                    $reputation ?? 'unknown',
+                    !empty($matchedCategories) ? ' (categories: ' . implode(', ', $matchedCategories) . ')' : ''
+                ),
+                url: $url,
+                metadata: [
+                    'reputation' => $reputation,
+                    'categories' => $categories,
+                    'matched_categories' => $matchedCategories,
+                ]
+            );
+
+            $result->addThreat($this->getName(), $threat);
+        }
+    }
+
+    /**
+     * Determine the primary threat type from matched categories.
+     *
+     * @param array<string> $categories
+     * @param string $reputation
+     * @return string
+     */
+    private function determineThreatType(array $categories, string $reputation): string
+    {
+        if (in_array('malware', $categories, true) || in_array('ransomware', $categories, true)) {
+            return 'MALWARE';
+        }
+
+        if (in_array('phishing', $categories, true)) {
+            return 'PHISHING';
+        }
+
+        if (in_array('spam', $categories, true)) {
+            return 'SPAM';
+        }
+
+        if (in_array('botnets', $categories, true)) {
+            return 'BOTNET';
+        }
+
+        if (in_array('exploit_kit', $categories, true)) {
+            return 'EXPLOIT_KIT';
+        }
+
+        if (in_array('cryptomining', $categories, true)) {
+            return 'CRYPTOMINING';
+        }
+
+        return 'UNTRUSTED';
+    }
+
+    /**
+     * Extract domain from URL.
+     *
+     * @param string $url
+     * @return string
+     */
+    private function extractDomain(string $url): string
+    {
+        $parsed = parse_url($url);
+
+        return $parsed['host'] ?? $url;
+    }
+}

--- a/src/Provider/FacebookProvider.php
+++ b/src/Provider/FacebookProvider.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qdenka\UltimateLinkChecker\Provider;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Psr7\HttpFactory;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Qdenka\UltimateLinkChecker\Contract\AbstractProvider;
+use Qdenka\UltimateLinkChecker\Exception\ProviderException;
+use Qdenka\UltimateLinkChecker\Result\CheckResult;
+use Qdenka\UltimateLinkChecker\Result\Threat;
+
+/**
+ * Facebook URL Security provider.
+ *
+ * Uses the Facebook Graph API to check URL sharing safety.
+ * Requires a valid Facebook App access token (app_id|app_secret).
+ */
+final class FacebookProvider extends AbstractProvider
+{
+    private const API_URL = 'https://graph.facebook.com/v18.0/';
+
+    public function __construct(
+        string $apiKey,
+        ?ClientInterface $httpClient = null,
+        ?RequestFactoryInterface $requestFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
+        float $timeout = 5.0,
+        int $retries = 1
+    ) {
+        parent::__construct(
+            $apiKey,
+            $httpClient ?? new Client(['timeout' => $timeout]),
+            $requestFactory ?? new HttpFactory(),
+            $streamFactory ?? new HttpFactory(),
+            $timeout,
+            $retries
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'facebook';
+    }
+
+    /**
+     * @param string $url
+     * @return CheckResult
+     * @throws ProviderException
+     */
+    public function check(string $url): CheckResult
+    {
+        $normalizedUrl = $this->normalizeUrl($url);
+        $result = $this->createResult($normalizedUrl);
+
+        try {
+            return $this->executeWithRetry(function () use ($normalizedUrl, $result): CheckResult {
+                $queryParams = http_build_query([
+                    'access_token' => $this->apiKey,
+                    'scrape' => 'true',
+                    'id' => $normalizedUrl,
+                ]);
+
+                $request = $this->requestFactory->createRequest('POST', self::API_URL . '?' . $queryParams)
+                    ->withHeader('Content-Type', 'application/x-www-form-urlencoded');
+
+                $response = $this->httpClient->sendRequest($request);
+                $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+                // Facebook flags unsafe URLs in the 'og_object' or via error responses
+                if (isset($data['error'])) {
+                    $errorMessage = $data['error']['message'] ?? 'Unknown error';
+
+                    // Error code 1 with specific messages indicates blocked/unsafe URL
+                    if ($this->isSecurityError($data['error'])) {
+                        $threat = new Threat(
+                            type: 'BLOCKED_URL',
+                            platform: 'FACEBOOK',
+                            description: sprintf('This URL is blocked by Facebook: %s', $errorMessage),
+                            url: $normalizedUrl,
+                            metadata: $data['error']
+                        );
+
+                        $result->addThreat($this->getName(), $threat);
+                    }
+                }
+
+                // Check if the share is restricted
+                if (isset($data['share']) && isset($data['share']['error'])) {
+                    $threat = new Threat(
+                        type: 'RESTRICTED_URL',
+                        platform: 'FACEBOOK',
+                        description: 'This URL has sharing restrictions on Facebook',
+                        url: $normalizedUrl,
+                        metadata: $data['share']
+                    );
+
+                    $result->addThreat($this->getName(), $threat);
+                }
+
+                return $result;
+            });
+        } catch (GuzzleException $e) {
+            throw new ProviderException(
+                sprintf('Error checking URL with Facebook: %s', $e->getMessage()),
+                $e->getCode(),
+                $e
+            );
+        }
+    }
+
+    /**
+     * Determine if a Facebook API error indicates a security issue.
+     *
+     * @param array<string, mixed> $error
+     * @return bool
+     */
+    private function isSecurityError(array $error): bool
+    {
+        $securityKeywords = ['spam', 'abuse', 'malicious', 'unsafe', 'blocked', 'restricted'];
+        $message = strtolower($error['message'] ?? '');
+
+        foreach ($securityKeywords as $keyword) {
+            if (str_contains($message, $keyword)) {
+                return true;
+            }
+        }
+
+        // Facebook error code 368 = temporarily blocked for policies
+        // Facebook error code 1609005 = link blocked
+        $blockedCodes = [368, 1609005];
+
+        return in_array($error['code'] ?? 0, $blockedCodes, true);
+    }
+}

--- a/src/Provider/OPSWATProvider.php
+++ b/src/Provider/OPSWATProvider.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qdenka\UltimateLinkChecker\Provider;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Psr7\HttpFactory;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Qdenka\UltimateLinkChecker\Contract\AbstractProvider;
+use Qdenka\UltimateLinkChecker\Exception\ProviderException;
+use Qdenka\UltimateLinkChecker\Result\CheckResult;
+use Qdenka\UltimateLinkChecker\Result\Threat;
+
+/**
+ * OPSWAT MetaDefender URL reputation provider.
+ *
+ * Uses the OPSWAT MetaDefender Cloud API v4 to check URL reputation.
+ * Requires a valid MetaDefender Cloud API key.
+ */
+final class OPSWATProvider extends AbstractProvider
+{
+    private const API_URL = 'https://api.metadefender.com/v4/url';
+
+    public function __construct(
+        string $apiKey,
+        ?ClientInterface $httpClient = null,
+        ?RequestFactoryInterface $requestFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
+        float $timeout = 5.0,
+        int $retries = 1
+    ) {
+        parent::__construct(
+            $apiKey,
+            $httpClient ?? new Client(['timeout' => $timeout]),
+            $requestFactory ?? new HttpFactory(),
+            $streamFactory ?? new HttpFactory(),
+            $timeout,
+            $retries
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'opswat';
+    }
+
+    /**
+     * @param string $url
+     * @return CheckResult
+     * @throws ProviderException
+     */
+    public function check(string $url): CheckResult
+    {
+        $normalizedUrl = $this->normalizeUrl($url);
+        $result = $this->createResult($normalizedUrl);
+
+        try {
+            return $this->executeWithRetry(function () use ($normalizedUrl, $result): CheckResult {
+                $payload = json_encode(['url' => $normalizedUrl], JSON_THROW_ON_ERROR);
+
+                $request = $this->requestFactory->createRequest('POST', self::API_URL)
+                    ->withHeader('apikey', $this->apiKey)
+                    ->withHeader('Content-Type', 'application/json');
+
+                $request = $request->withBody(
+                    $this->streamFactory->createStream($payload)
+                );
+
+                $response = $this->httpClient->sendRequest($request);
+                $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+                $this->processResults($data, $normalizedUrl, $result);
+
+                return $result;
+            });
+        } catch (GuzzleException $e) {
+            throw new ProviderException(
+                sprintf('Error checking URL with OPSWAT MetaDefender: %s', $e->getMessage()),
+                $e->getCode(),
+                $e
+            );
+        }
+    }
+
+    /**
+     * Process OPSWAT API results and add threats if found.
+     *
+     * @param array<string, mixed> $data
+     * @param string $url
+     * @param CheckResult $result
+     */
+    private function processResults(array $data, string $url, CheckResult $result): void
+    {
+        // OPSWAT returns lookup_results with detected_by count
+        $lookupResults = $data['lookup_results'] ?? [];
+        $detectedBy = $lookupResults['detected_by'] ?? 0;
+
+        if ($detectedBy > 0) {
+            $sources = $lookupResults['sources'] ?? [];
+            $maliciousSources = [];
+
+            foreach ($sources as $source) {
+                $assessment = $source['assessment'] ?? '';
+                if (in_array($assessment, ['malware', 'phishing', 'suspicious', 'spam', 'potentially_malicious'], true)) {
+                    $maliciousSources[] = [
+                        'provider' => $source['provider'] ?? 'unknown',
+                        'assessment' => $assessment,
+                    ];
+                }
+            }
+
+            if (!empty($maliciousSources)) {
+                $threatType = $this->determineThreatType($maliciousSources);
+                $providerNames = array_map(fn(array $s) => $s['provider'], $maliciousSources);
+
+                $threat = new Threat(
+                    type: $threatType,
+                    platform: 'ANY_PLATFORM',
+                    description: sprintf(
+                        'This URL was flagged by %d source(s) in OPSWAT MetaDefender: %s',
+                        count($maliciousSources),
+                        implode(', ', array_slice($providerNames, 0, 5))
+                    ),
+                    url: $url,
+                    metadata: [
+                        'detected_by' => $detectedBy,
+                        'sources' => $maliciousSources,
+                        'start_time' => $data['lookup_results']['start_time'] ?? null,
+                    ]
+                );
+
+                $result->addThreat($this->getName(), $threat);
+            }
+        }
+    }
+
+    /**
+     * Determine the primary threat type from malicious sources.
+     *
+     * @param array<array{provider: string, assessment: string}> $sources
+     * @return string
+     */
+    private function determineThreatType(array $sources): string
+    {
+        $assessments = array_column($sources, 'assessment');
+
+        if (in_array('malware', $assessments, true)) {
+            return 'MALWARE';
+        }
+
+        if (in_array('phishing', $assessments, true)) {
+            return 'PHISHING';
+        }
+
+        if (in_array('spam', $assessments, true)) {
+            return 'SPAM';
+        }
+
+        return 'SUSPICIOUS';
+    }
+}

--- a/src/Provider/YandexSafeBrowsingProvider.php
+++ b/src/Provider/YandexSafeBrowsingProvider.php
@@ -23,13 +23,17 @@ final class YandexSafeBrowsingProvider extends AbstractProvider
         string $apiKey,
         ?ClientInterface $httpClient = null,
         ?RequestFactoryInterface $requestFactory = null,
-        ?StreamFactoryInterface $streamFactory = null
+        ?StreamFactoryInterface $streamFactory = null,
+        float $timeout = 5.0,
+        int $retries = 1
     ) {
         parent::__construct(
             $apiKey,
-            $httpClient ?? new Client(),
+            $httpClient ?? new Client(['timeout' => $timeout]),
             $requestFactory ?? new HttpFactory(),
-            $streamFactory ?? new HttpFactory()
+            $streamFactory ?? new HttpFactory(),
+            $timeout,
+            $retries
         );
     }
 
@@ -45,8 +49,6 @@ final class YandexSafeBrowsingProvider extends AbstractProvider
      * @param string $url
      * @return CheckResult
      * @throws ProviderException
-     * @throws \JsonException
-     * @throws \Psr\Http\Client\ClientExceptionInterface
      */
     public function check(string $url): CheckResult
     {
@@ -54,31 +56,35 @@ final class YandexSafeBrowsingProvider extends AbstractProvider
         $result = $this->createResult($normalizedUrl);
 
         try {
-            $payload = $this->buildRequestPayload([$normalizedUrl]);
-            $request = $this->requestFactory->createRequest('POST', $this->getApiUrl())
-                ->withHeader('Content-Type', 'application/json')
-                ->withHeader('Authorization', 'ApiKey ' . $this->apiKey);
+            return $this->executeWithRetry(function () use ($normalizedUrl, $result): CheckResult {
+                $payload = $this->buildRequestPayload([$normalizedUrl]);
+                $request = $this->requestFactory->createRequest('POST', self::API_URL)
+                    ->withHeader('Content-Type', 'application/json')
+                    ->withHeader('Authorization', 'ApiKey ' . $this->apiKey);
 
-            $request = $request->withBody(
-                $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR))
-            );
+                $request = $request->withBody(
+                    $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR))
+                );
 
-            $response = $this->httpClient->sendRequest($request);
-            $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+                $response = $this->httpClient->sendRequest($request);
+                $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
 
-            if (isset($data['matches']) && is_array($data['matches'])) {
-                foreach ($data['matches'] as $match) {
-                    $threat = new Threat(
-                        type: $match['threatType'] ?? 'UNKNOWN',
-                        platform: $match['platformType'] ?? 'ANY_PLATFORM',
-                        description: $this->getThreatDescription($match['threatType'] ?? 'UNKNOWN'),
-                        url: $match['threat']['url'] ?? $normalizedUrl,
-                        metadata: $match
-                    );
+                if (isset($data['matches']) && is_array($data['matches'])) {
+                    foreach ($data['matches'] as $match) {
+                        $threat = new Threat(
+                            type: $match['threatType'] ?? 'UNKNOWN',
+                            platform: $match['platformType'] ?? 'ANY_PLATFORM',
+                            description: $this->getThreatDescription($match['threatType'] ?? 'UNKNOWN'),
+                            url: $match['threat']['url'] ?? $normalizedUrl,
+                            metadata: $match
+                        );
 
-                    $result->addThreat($this->getName(), $threat);
+                        $result->addThreat($this->getName(), $threat);
+                    }
                 }
-            }
+
+                return $result;
+            });
         } catch (GuzzleException $e) {
             throw new ProviderException(
                 sprintf('Error checking URL with Yandex Safe Browsing: %s', $e->getMessage()),
@@ -86,8 +92,6 @@ final class YandexSafeBrowsingProvider extends AbstractProvider
                 $e
             );
         }
-
-        return $result;
     }
 
     /**
@@ -118,14 +122,6 @@ final class YandexSafeBrowsingProvider extends AbstractProvider
                 'threatEntries' => $threatEntries
             ]
         ];
-    }
-
-    /**
-     * @return string
-     */
-    private function getApiUrl(): string
-    {
-        return self::API_URL;
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR addresses all issues found during the code audit: bug fixes, missing implementations, and code quality improvements.

## Bug Fixes

### 🐛 Consensus logic was inverted (`AggregateResult`)
The `CONSENSUS_ANY` and `CONSENSUS_ALL` strategies were **swapped**:
- `ANY` should mean "unsafe if ANY provider flags it" (strictest) → was doing the opposite
- `ALL` should mean "unsafe only if ALL flag it" (most lenient) → was doing the opposite
- Now uses `$unsafeCount` instead of `$safeCount` for clarity

### 🐛 Async was fake (`UltimateLinkChecker`)
`checkAsync()` was just wrapping synchronous `check()` in `React\Promise\resolve()`. Now uses `Deferred` promises properly so each provider check resolves independently through `React\Promise\all()`.

### 🐛 README examples had wrong API calls
- `$result->getThreatType()` doesn't exist on `AggregateResult` — fixed examples to use `getThreats()` with proper nested iteration
- `getThreats()` returns `array<string, array<Threat>>`, examples now iterate correctly

## Missing Implementations

### 3 New Providers
- **`FacebookProvider`** — Uses Graph API v18.0 to check URL sharing safety, detects blocked/restricted URLs
- **`OPSWATProvider`** — Uses MetaDefender Cloud API v4 for multi-source URL reputation scanning
- **`CiscoTalosProvider`** — Uses Cisco Talos reputation API, checks domain reputation and threat categories

### Config → Provider Integration
- `timeout` and `retries` from `CheckerConfig` were never passed to providers — `AbstractProvider` now accepts these parameters
- All providers pass `timeout` to Guzzle `Client` constructor
- Added `executeWithRetry()` method in `AbstractProvider` with incremental backoff

### PSR-3 Logging
- Replaced dead `logEnabled` boolean with actual `PSR-3 LoggerInterface` support
- `CheckerConfig` now has `setLogger()` / `getLogger()` (defaults to `NullLogger`)
- `UltimateLinkChecker` logs provider checks, cache hits, and errors

## Code Quality

- Removed `#[Pure]` JetBrains attribute (not in composer dependencies)
- Fixed `CheckerConfig` union type `CacheInterface|NullCacheAdapter|null` → `?CacheInterface` (NullCacheAdapter implements CacheInterface)
- Updated `ProviderFactory` with all 8 providers + `timeout`/`retries` params
- Updated README to accurately reflect the actual API

## Files Changed

| File | Change |
|---|---|
| `src/Result/AggregateResult.php` | Fix consensus logic |
| `src/Contract/AbstractProvider.php` | Add timeout, retries, executeWithRetry() |
| `src/Config/CheckerConfig.php` | PSR-3 logger, fix types |
| `src/UltimateLinkChecker.php` | Real async, logging |
| `src/Provider/GoogleSafeBrowsingProvider.php` | Add timeout/retries/retry |
| `src/Provider/YandexSafeBrowsingProvider.php` | Add timeout/retries/retry |
| `src/Provider/VirusTotalProvider.php` | Add timeout/retries/retry |
| `src/Provider/PhishTankProvider.php` | Add timeout/retries/retry |
| `src/Provider/IPQualityScoreProvider.php` | Add timeout/retries/retry |
| `src/Provider/FacebookProvider.php` | **NEW** |
| `src/Provider/OPSWATProvider.php` | **NEW** |
| `src/Provider/CiscoTalosProvider.php` | **NEW** |
| `src/Factory/ProviderFactory.php` | Add new providers + params |
| `README.md` | Fix examples, document all providers |